### PR TITLE
Test Cypress 10 with a new code of @knapsack-pro/cypress

### DIFF
--- a/bin/setup_development
+++ b/bin/setup_development
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# use --legacy-peer-deps because kitchensink project has conflicts in peer dependencies
+# use --legacy-peer-deps because the kitchensink project has conflicts in peer dependencies
 npm install --legacy-peer-deps
 
 $(npm bin)/cypress install

--- a/bin/setup_development
+++ b/bin/setup_development
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# --legacy-peer-deps temporary change
+# use --legacy-peer-deps because kitchensink project has conflicts in peer dependencies
 npm install --legacy-peer-deps
 
 $(npm bin)/cypress install

--- a/bin/setup_development
+++ b/bin/setup_development
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# --legacy-peer-deps temporary change
 npm install --legacy-peer-deps
 
 $(npm bin)/cypress install

--- a/circle.yml
+++ b/circle.yml
@@ -90,4 +90,4 @@ jobs:
           command: npm run start
           background: true
 
-      - run: $(npm bin)/knapsack-pro-cypress
+      - run: $(npm bin)/knapsack-pro-cypress --record true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11301,6 +11301,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -11316,16 +11317,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11340,6 +11344,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -11357,6 +11362,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -26719,7 +26725,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -26732,15 +26739,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -26752,7 +26762,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -26766,7 +26777,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",


### PR DESCRIPTION
This PR has a branch name the same as the branch name for [the following PR in @knapsack-pro/cypress](https://github.com/KnapsackPro/knapsack-pro-cypress/pull/77). Thanks to that we can run on CI the code base of @knapsack-pro/cypress from [the following PR](https://github.com/KnapsackPro/knapsack-pro-cypress/pull/77) and test it against this kitchensink project. 

The kitchensink project is based on up to date upstream codebase using Cypress 10: https://github.com/KnapsackPro/cypress-example-kitchensink/pull/7

# related
https://github.com/KnapsackPro/knapsack-pro-cypress/pull/77