### PR TITLE
Install Cypress 10.1.0, make CI build passing, update @knapsack-pro/cypress 5.1.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -90,4 +90,4 @@ jobs:
           command: npm run start
           background: true
 
-      - run: TEST_FILE_PATTERN="cypress/e2e/**/ass*.{js,jsx,coffee,cjsx}" $(npm bin)/knapsack-pro-cypress --record true
+      - run: $(npm bin)/knapsack-pro-cypress --record true

--- a/circle.yml
+++ b/circle.yml
@@ -90,4 +90,4 @@ jobs:
           command: npm run start
           background: true
 
-      - run: $(npm bin)/knapsack-pro-cypress --record true
+      - run: TEST_FILE_PATTERN="cypress/e2e/**/ass*.{js,jsx,coffee,cjsx}" $(npm bin)/knapsack-pro-cypress --record true

--- a/circle.yml
+++ b/circle.yml
@@ -90,4 +90,4 @@ jobs:
           command: npm run start
           background: true
 
-      - run: $(npm bin)/knapsack-pro-cypress --record true
+      - run: $(npm bin)/knapsack-pro-cypress --record false

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@cypress/eslint-plugin-dev": "5.0.0",
         "@knapsack-pro/cypress": "5.0.0",
         "colon-names": "1.0.0",
-        "cypress": "10.0.0",
+        "cypress": "10.1.0",
         "eslint": "7.0.0",
         "eslint-plugin-cypress": "2.8.1",
         "eslint-plugin-json-format": "2.0.1",
@@ -3025,9 +3025,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.0.tgz",
-      "integrity": "sha512-OdND7TaYZcDD+UYBlL6VCEMZcsclliG9TY/T6zLzeGtwOf5dwi+41nU9XAZzSbByoqturb8HS4G/+XD8PthN5w==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz",
+      "integrity": "sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -20332,9 +20332,9 @@
       }
     },
     "cypress": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.0.tgz",
-      "integrity": "sha512-OdND7TaYZcDD+UYBlL6VCEMZcsclliG9TY/T6zLzeGtwOf5dwi+41nU9XAZzSbByoqturb8HS4G/+XD8PthN5w==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz",
+      "integrity": "sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@bahmutov/print-env": "1.2.0",
         "@cypress/eslint-plugin-dev": "5.0.0",
-        "@knapsack-pro/cypress": "5.0.0",
+        "@knapsack-pro/cypress": "5.1.0",
         "colon-names": "1.0.0",
         "cypress": "10.1.0",
         "eslint": "7.0.0",
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@knapsack-pro/cypress": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/cypress/-/cypress-5.0.0.tgz",
-      "integrity": "sha512-e8fKf7z+VvWI3f0nfPGBHmxIRO6iIOlnkV9iiX21V5koujfTea9QPnRfepgtWDrzhF9ksIu/hg+qTXGs4C5ecQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/cypress/-/cypress-5.1.0.tgz",
+      "integrity": "sha512-0R7Bd+lKH4cD/CbjKQyxbIw6YD+KgCzmFxeJByn7Tf0WfojPUg76FytgSc4XvFPdZFjUqa90mZjyUsmdLch6Iw==",
       "dev": true,
       "dependencies": {
         "@knapsack-pro/core": "^3.2.0",
@@ -18123,9 +18123,9 @@
       }
     },
     "@knapsack-pro/cypress": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/cypress/-/cypress-5.0.0.tgz",
-      "integrity": "sha512-e8fKf7z+VvWI3f0nfPGBHmxIRO6iIOlnkV9iiX21V5koujfTea9QPnRfepgtWDrzhF9ksIu/hg+qTXGs4C5ecQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/cypress/-/cypress-5.1.0.tgz",
+      "integrity": "sha512-0R7Bd+lKH4cD/CbjKQyxbIw6YD+KgCzmFxeJByn7Tf0WfojPUg76FytgSc4XvFPdZFjUqa90mZjyUsmdLch6Iw==",
       "dev": true,
       "requires": {
         "@knapsack-pro/core": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@bahmutov/print-env": "1.2.0",
     "@cypress/eslint-plugin-dev": "5.0.0",
     "colon-names": "1.0.0",
-    "cypress": "10.0.0",
+    "cypress": "10.1.0",
     "eslint": "7.0.0",
     "eslint-plugin-cypress": "2.8.1",
     "eslint-plugin-json-format": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "serve": "11.3.0"
   },
   "devDependencies": {
-    "@knapsack-pro/cypress": "5.0.0",
+    "@knapsack-pro/cypress": "5.1.0",
     "@bahmutov/print-env": "1.2.0",
     "@cypress/eslint-plugin-dev": "5.0.0",
     "colon-names": "1.0.0",


### PR DESCRIPTION
# changes

* install Cypress 10.1.0 on CI to match the Cypress version in devDependecies for the `@knapsack-pro/cypress` repository. Thanks to that we can run tests for the kitchensink project on CI  using the local copy of  `@knapsack-pro/cypress` repository.

* There was a problem and tests were not executed but CI was passing green. This problem occurred just because we recently upgraded Cypress in the `@knapsack-pro/cypress` repo but not in the kitchensink project. 
I missed the problem because CI was passing green when Cypress raised an exception. I handle the exception now in this PR https://github.com/KnapsackPro/knapsack-pro-cypress/pull/79 so that we can exit the process with `1` exit code. 

  * Update `@knapsack-pro/cypress` to 5.1.0

* Disable cypress record on CI to fit the free plan limit

# related

https://github.com/KnapsackPro/knapsack-pro-cypress/pull/79